### PR TITLE
Explicitly include only necessary files during package install

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "description": "Node.js SDK for the LINE Messaging API",
   "main": "index.js",
+  "files": ["index.js", "lib/**"],
   "scripts": {
     "start": "node examples/demo.js",
     "test": "mocha"


### PR DESCRIPTION
This should do the work. Whitelisting in this case is more useful than blacklisting using `.npmignore`.

Fixes: https://github.com/boybundit/linebot/issues/4