### PR TITLE
Add support for official multicast

### DIFF
--- a/examples/demo.js
+++ b/examples/demo.js
@@ -35,6 +35,9 @@ bot.on('message', function (event) {
 				case 'Push':
 					bot.push('U6350b7606935db981705282747c82ee1', ['Hey!', 'สวัสดี ' + String.fromCharCode(0xD83D, 0xDE01)]);
 					break;
+				case 'Multicast':
+					bot.push(['U6350b7606935db981705282747c82ee1', 'U6350b7606935db981705282747c82ee1'], 'Multicast!');
+					break;
 				case 'Confirm':
 					event.reply({
 						type: 'template',

--- a/lib/linebot.js
+++ b/lib/linebot.js
@@ -95,6 +95,16 @@ class LineBot extends EventEmitter {
 		});
 	}
 
+	multicast(to, message) {
+		const body = {
+			to: to,
+			messages: LineBot.createMessages(message)
+		};
+		return this.post('/message/multicast', body).then(function (res) {
+			return res.json();
+		});
+	}
+
 	getUserProfile(userId) {
 		return this.get('/profile/' + userId).then(function (res) {
 			return res.json();

--- a/test/linebot.test.js
+++ b/test/linebot.test.js
@@ -85,10 +85,16 @@ describe('linebot', function () {
 			const res = bot.push('to', 'message');
 			assert.equal(Promise, res.constructor);
 		});
-		it('should resolve multiple promises', function () {
+		it('should resolve multiple promises.', function () {
 			bot.push(['1', '2', '3'], 'message').then(function (results) {
 				assert.equal(results.length, 3);
 			});
+		});
+	});
+	describe('#multicast()', function () {
+		it('should return a promise.', function () {
+			const res = bot.push(['to'], 'message');
+			assert.equal(Promise, res.constructor);
 		});
 	});
 	describe('#getUserProfile()', function () {


### PR DESCRIPTION
We support pushing messages to many users by calling push for each users. LINE Messaging API has added support for [multicast ](https://devdocs.line.me/en/#multicast)to 150 users in one call. The PR implements multicast method by calling this new multicast endpoint.
