### PR TITLE
fix: add empty check for options

### DIFF
--- a/lib/linebot.js
+++ b/lib/linebot.js
@@ -15,6 +15,15 @@ class LineBot extends EventEmitter {
     this.options.channelId = options.channelId || '';
     this.options.channelSecret = options.channelSecret || '';
     this.options.channelAccessToken = options.channelAccessToken || '';
+    if (this.options.channelId === '') {
+      throw new Error("channelId cannot be empty")
+    }
+    if (this.options.channelSecret === '') {
+      throw new Error("channelSecret cannot be empty")
+    }
+    if (this.options.channelAccessToken === '') {
+      throw new Error("channelAccessToken cannot be empty")
+    }
     if (this.options.verify === undefined) {
       this.options.verify = true;
     }


### PR DESCRIPTION
channelId, channelSecret and channelAccessToken should be
present for the bot in order to function properly.

Past behaviour: when a channelSecret is not given, webhook requests
are simply returned 400 Bad Request by the verify function.

After this commit, the constructor will throw an error when any of the
above options are not given.

Haven't written the tests yet.

Signed-off-by: Birkhoff Lee <git@birkhoff.me>