### PR TITLE
add getBotInfo method

### DIFF
--- a/lib/linebot.js
+++ b/lib/linebot.js
@@ -294,6 +294,15 @@ class LineBot extends EventEmitter {
     });
   }
 
+  getBotInfo() {
+    const url = '/info';
+    debug('GET %s', url);
+    return this.get(url).then(res => res.json()).then((botInfo) => {
+      debug('%O', botInfo);
+      return botInfo;
+    });
+  }
+
   get(path) {
     const url = this.endpoint + path;
     const options = { method: 'GET', headers: this.headers };


### PR DESCRIPTION
add getBotInfo method for get bot basic information it helpful for check chatMode (chat or bot) 
example result for getBotInfo API
{
  "userId": "Ub9952f8...",
  "basicId": "@216ru...",
  "displayName": "Example name",
  "pictureUrl": "https://obs.line-apps.com/...",
  "chatMode": "chat",
  "markAsReadMode": "manual"
}